### PR TITLE
New functionality (Locks/ Authenticate Modes)

### DIFF
--- a/Adapters/AuthenticationTypes/HttpListenerAnyonymousAdapter.cs
+++ b/Adapters/AuthenticationTypes/HttpListenerAnyonymousAdapter.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Net;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Security.Principal;
+using System.Threading;
+using Microsoft.Win32.SafeHandles;
+
+namespace WebDAVSharp.Server.Adapters.AuthenticationTypes
+{
+    class HttpListenerAnyonymousAdapter : WebDavDisposableBase, IHttpListener, IAdapter<HttpListener>
+    {
+        public HttpListenerAnyonymousAdapter()
+        {
+            AdaptedInstance = new HttpListener
+            {
+                AuthenticationSchemes = AuthenticationSchemes.Anonymous,
+                UnsafeConnectionNtlmAuthentication = false
+            };
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (AdaptedInstance.IsListening)
+                AdaptedInstance.Close();
+        }
+
+        public HttpListener AdaptedInstance
+        {
+            get;
+            private set;
+        }
+
+        public IHttpListenerContext GetContext(EventWaitHandle abortEvent)
+        {
+            if (abortEvent == null)
+                throw new ArgumentNullException("abortEvent");
+
+            IAsyncResult ar = AdaptedInstance.BeginGetContext(null, null);
+            int index = WaitHandle.WaitAny(new[] { abortEvent, ar.AsyncWaitHandle });
+            if (index != 1)
+                return null;
+            HttpListenerContext context = AdaptedInstance.EndGetContext(ar);
+            return new HttpListenerContextAdapter(context);
+        }
+
+        public HttpListenerPrefixCollection Prefixes
+        {
+            get
+            {
+                return AdaptedInstance.Prefixes;
+            }
+        }
+
+        public void Start()
+        {
+            AdaptedInstance.Start();
+        }
+
+        public void Stop()
+        {
+            AdaptedInstance.Stop();
+        }
+
+        public IIdentity GetIdentity(IHttpListenerContext context)
+        {
+            return WindowsIdentity.GetCurrent();
+        }
+
+
+
+    }
+}

--- a/Adapters/AuthenticationTypes/HttpListenerBasicAdapter.cs
+++ b/Adapters/AuthenticationTypes/HttpListenerBasicAdapter.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Net;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Security.Principal;
+using System.Threading;
+using Microsoft.Win32.SafeHandles;
+
+namespace WebDAVSharp.Server.Adapters.AuthenticationTypes
+{
+    class HttpListenerBasicAdapter : WebDavDisposableBase, IHttpListener, IAdapter<HttpListener>
+    {
+        #region Imports
+        [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern bool LogonUser(String lpszUsername, String lpszDomain, String lpszPassword, int dwLogonType, int dwLogonProvider, out SafeTokenHandle phToken);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+        public static extern bool CloseHandle(IntPtr handle);
+
+        #endregion
+
+        public HttpListenerBasicAdapter()
+        {
+            AdaptedInstance = new HttpListener
+            {
+                AuthenticationSchemes = AuthenticationSchemes.Basic,
+                UnsafeConnectionNtlmAuthentication = false
+            };
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (AdaptedInstance.IsListening)
+                AdaptedInstance.Close();
+        }
+
+        public HttpListener AdaptedInstance
+        {
+            get;
+            private set;
+        }
+
+        public IHttpListenerContext GetContext(EventWaitHandle abortEvent)
+        {
+            if (abortEvent == null)
+                throw new ArgumentNullException("abortEvent");
+
+            IAsyncResult ar = AdaptedInstance.BeginGetContext(null, null);
+            int index = WaitHandle.WaitAny(new[] { abortEvent, ar.AsyncWaitHandle });
+            if (index != 1)
+                return null;
+            HttpListenerContext context = AdaptedInstance.EndGetContext(ar);
+            return new HttpListenerContextAdapter(context);
+        }
+
+        public HttpListenerPrefixCollection Prefixes
+        {
+            get
+            {
+                return AdaptedInstance.Prefixes;
+            }
+        }
+
+        public void Start()
+        {
+            AdaptedInstance.Start();
+        }
+
+        public void Stop()
+        {
+            AdaptedInstance.Stop();
+        }
+
+        public IIdentity GetIdentity(IHttpListenerContext context)
+        {
+            HttpListenerBasicIdentity ident = (HttpListenerBasicIdentity)context.AdaptedInstance.User.Identity;
+            string domain = ident.Name.Split('\\')[0];
+            string username = ident.Name.Split('\\')[1];
+            var token = GetToken(domain, username, ident.Password);
+            return new WindowsIdentity(token.DangerousGetHandle());
+        }
+
+
+
+        internal static SafeTokenHandle GetToken(string domainName,
+            string userName, string password)
+        {
+            SafeTokenHandle safeTokenHandle;
+
+            const int LOGON32_PROVIDER_DEFAULT = 0;
+            //This parameter causes LogonUser to create a primary token.
+            const int LOGON32_LOGON_INTERACTIVE = 2;
+
+            // Call LogonUser to obtain a handle to an access token.
+            bool returnValue = LogonUser(userName, domainName, password,
+                LOGON32_LOGON_INTERACTIVE, LOGON32_PROVIDER_DEFAULT,
+                out safeTokenHandle);
+
+            if (returnValue) return safeTokenHandle;
+            int ret = Marshal.GetLastWin32Error();
+            throw new System.ComponentModel.Win32Exception(ret);
+        }
+
+        public sealed class SafeTokenHandle : SafeHandleZeroOrMinusOneIsInvalid
+        {
+            private SafeTokenHandle()
+                : base(true)
+            {
+            }
+
+            [DllImport("kernel32.dll")]
+            [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+            [SuppressUnmanagedCodeSecurity]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            private static extern bool CloseHandle(IntPtr handle);
+
+            protected override bool ReleaseHandle()
+            {
+                return CloseHandle(handle);
+            }
+        }
+    }
+}

--- a/Adapters/AuthenticationTypes/HttpListenerNegotiateAdapter.cs
+++ b/Adapters/AuthenticationTypes/HttpListenerNegotiateAdapter.cs
@@ -1,15 +1,16 @@
 ﻿using System;
 using System.Net;
+using System.Security.Principal;
 using System.Threading;
 
-namespace WebDAVSharp.Server.Adapters
+namespace WebDAVSharp.Server.Adapters.AuthenticationTypes
 {
     /// <summary>
     /// This 
     /// <see cref="IHttpListener" /> implementation wraps around a
     /// <see cref="HttpListener" /> instance.
     /// </summary>
-    internal sealed class HttpListenerAdapter : WebDavDisposableBase, IHttpListener, IAdapter<HttpListener>
+    internal sealed class HttpListenerNegotiateAdapter : WebDavDisposableBase, IHttpListener, IAdapter<HttpListener>
     {
         #region Private Variables
 
@@ -49,9 +50,9 @@ namespace WebDAVSharp.Server.Adapters
 
         #region Constructor
         /// <summary>
-        /// Initializes a new instance of the <see cref="HttpListenerAdapter" /> class.
+        /// Initializes a new instance of the <see cref="HttpListenerNegotiateAdapter" /> class.
         /// </summary>
-        internal HttpListenerAdapter()
+        internal HttpListenerNegotiateAdapter()
         {
             _listener = new HttpListener
             {
@@ -119,6 +120,11 @@ namespace WebDAVSharp.Server.Adapters
         public void Stop()
         {
             _listener.Stop();
+        }
+
+        public IIdentity GetIdentity(IHttpListenerContext context)
+        {
+            return context.AdaptedInstance.User.Identity;
         }
 
         #endregion

--- a/Adapters/HttpListenerAdapter.cs
+++ b/Adapters/HttpListenerAdapter.cs
@@ -11,8 +11,43 @@ namespace WebDAVSharp.Server.Adapters
     /// </summary>
     internal sealed class HttpListenerAdapter : WebDavDisposableBase, IHttpListener, IAdapter<HttpListener>
     {
+        #region Private Variables
+
         private readonly HttpListener _listener;
 
+        #endregion
+
+        #region Properties
+        /// <summary>
+        /// Gets the internal instance that was adapted for WebDAV#.
+        /// </summary>
+        /// <value>
+        /// The adapted instance.
+        /// </value>
+        public HttpListener AdaptedInstance
+        {
+            get
+            {
+                return _listener;
+            }
+        }
+
+        /// <summary>
+        /// Gets the Uniform Resource Identifier (
+        /// <see cref="Uri" />) prefixes handled by the
+        /// adapted 
+        /// <see cref="HttpListener" /> object.
+        /// </summary>
+        public HttpListenerPrefixCollection Prefixes
+        {
+            get
+            {
+                return _listener.Prefixes;
+            }
+        }
+        #endregion
+
+        #region Constructor
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpListenerAdapter" /> class.
         /// </summary>
@@ -24,7 +59,9 @@ namespace WebDAVSharp.Server.Adapters
                 UnsafeConnectionNtlmAuthentication = false
             };
         }
+        #endregion
 
+        #region Function Overrides
         /// <summary>
         /// Releases unmanaged and - optionally - managed resources
         /// </summary>
@@ -34,6 +71,10 @@ namespace WebDAVSharp.Server.Adapters
             if (_listener.IsListening)
                 _listener.Close();
         }
+
+        #endregion
+
+        #region Public Functions
 
         /// <summary>
         /// Waits for a request to come in to the web server and returns a
@@ -63,35 +104,7 @@ namespace WebDAVSharp.Server.Adapters
             HttpListenerContext context = _listener.EndGetContext(ar);
             return new HttpListenerContextAdapter(context);
         }
-
-        /// <summary>
-        /// Gets the internal instance that was adapted for WebDAV#.
-        /// </summary>
-        /// <value>
-        /// The adapted instance.
-        /// </value>
-        public HttpListener AdaptedInstance
-        {
-            get
-            {
-                return _listener;
-            }
-        }
-
-        /// <summary>
-        /// Gets the Uniform Resource Identifier (
-        /// <see cref="Uri" />) prefixes handled by the
-        /// adapted 
-        /// <see cref="HttpListener" /> object.
-        /// </summary>
-        public HttpListenerPrefixCollection Prefixes
-        {
-            get
-            {
-                return _listener.Prefixes;
-            }
-        }
-
+        
         /// <summary>
         /// Allows the adapted <see cref="HttpListener" /> to receive incoming requests.
         /// </summary>
@@ -107,5 +120,7 @@ namespace WebDAVSharp.Server.Adapters
         {
             _listener.Stop();
         }
+
+        #endregion
     }
 }

--- a/Adapters/HttpListenerContextAdapter.cs
+++ b/Adapters/HttpListenerContextAdapter.cs
@@ -10,9 +10,15 @@ namespace WebDAVSharp.Server.Adapters
     /// </summary>
     internal sealed class HttpListenerContextAdapter : IHttpListenerContext, IAdapter<HttpListenerContext>
     {
+        #region Private Variables
+
         private readonly HttpListenerContext _context;
         private readonly HttpListenerRequestAdapter _request;
         private readonly HttpListenerResponseAdapter _response;
+
+        #endregion
+
+        #region Public Functions
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpListenerContextAdapter" /> class.
@@ -29,6 +35,10 @@ namespace WebDAVSharp.Server.Adapters
             _request = new HttpListenerRequestAdapter(context.Request);
             _response = new HttpListenerResponseAdapter(context.Response);
         }
+
+        #endregion
+
+        #region Properties
 
         /// <summary>
         /// Gets the internal instance that was adapted for WebDAV#.
@@ -65,5 +75,7 @@ namespace WebDAVSharp.Server.Adapters
                 return _response;
             }
         }
+
+        #endregion
     }
 }

--- a/Adapters/HttpListenerContextAdapter.cs
+++ b/Adapters/HttpListenerContextAdapter.cs
@@ -8,7 +8,7 @@ namespace WebDAVSharp.Server.Adapters
     /// <see cref="IHttpListenerContext" /> implementation wraps around a
     /// <see cref="HttpListenerContext" /> instance.
     /// </summary>
-    internal sealed class HttpListenerContextAdapter : IHttpListenerContext, IAdapter<HttpListenerContext>
+    public sealed class HttpListenerContextAdapter : IHttpListenerContext, IAdapter<HttpListenerContext>
     {
         #region Private Variables
 

--- a/Adapters/HttpListenerRequestAdapter.cs
+++ b/Adapters/HttpListenerRequestAdapter.cs
@@ -13,8 +13,13 @@ namespace WebDAVSharp.Server.Adapters
     /// </summary>
     internal sealed class HttpListenerRequestAdapter : IHttpListenerRequest
     {
+        #region Private Variables
+
         private readonly HttpListenerRequest _request;
 
+        #endregion
+
+        #region Public Functions
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpListenerRequestAdapter" /> class.
         /// </summary>
@@ -28,6 +33,10 @@ namespace WebDAVSharp.Server.Adapters
 
             _request = request;
         }
+
+        #endregion
+
+        #region Properties
 
         /// <summary>
         /// Gets the internal instance that was adapted for WebDAV#.
@@ -119,5 +128,7 @@ namespace WebDAVSharp.Server.Adapters
                 return _request.ContentLength64;
             }
         }
+
+        #endregion
     }
 }

--- a/Adapters/HttpListenerResponseAdapter.cs
+++ b/Adapters/HttpListenerResponseAdapter.cs
@@ -12,22 +12,13 @@ namespace WebDAVSharp.Server.Adapters
     /// </summary>
     internal sealed class HttpListenerResponseAdapter : IHttpListenerResponse
     {
+        #region Private Variables
+
         private readonly HttpListenerResponse _response;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="HttpListenerResponseAdapter" /> class.
-        /// </summary>
-        /// <param name="Response">The <see cref="HttpListenerResponse" /> to adapt for WebDAV#.</param>
-        /// <exception cref="System.ArgumentNullException">Response</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="Response" /> is <c>null</c>.</exception>
-        public HttpListenerResponseAdapter(HttpListenerResponse Response)
-        {
-        if (Response == null)
-            throw new ArgumentNullException("Response");
+        #endregion
 
-        _response = Response;
-        }
-
+        #region Properties
         /// <summary>
         /// Gets the internal instance that was adapted for WebDAV#.
         /// </summary>
@@ -117,6 +108,24 @@ namespace WebDAVSharp.Server.Adapters
             }
         }
 
+        #endregion
+
+        #region Public Functions
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpListenerResponseAdapter" /> class.
+        /// </summary>
+        /// <param name="response">The <see cref="HttpListenerResponse" /> to adapt for WebDAV#.</param>
+        /// <exception cref="System.ArgumentNullException">Response</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="response" /> is <c>null</c>.</exception>
+        public HttpListenerResponseAdapter(HttpListenerResponse response)
+        {
+        if (response == null)
+            throw new ArgumentNullException("response");
+
+        _response = response;
+        }
+
         /// <summary>
         /// Sends the response to the client and releases the resources held by the adapted
         /// <see cref="HttpListenerResponse" /> instance.
@@ -135,5 +144,7 @@ namespace WebDAVSharp.Server.Adapters
         {
             _response.AppendHeader(name, value);
         }
+
+        #endregion
     }
 }

--- a/Adapters/IHttpListener.cs
+++ b/Adapters/IHttpListener.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using System.Security.Principal;
 using System.Threading;
 
 namespace WebDAVSharp.Server.Adapters
@@ -55,5 +56,12 @@ namespace WebDAVSharp.Server.Adapters
         /// Causes the adapted <see cref="HttpListener" /> to stop receiving incoming requests.
         /// </summary>
         void Stop();
+
+        /// <summary>
+        /// Returns the windows Idenity to use for the request.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        IIdentity GetIdentity(IHttpListenerContext context);
     }
 }

--- a/MethodHandlers/WebDAVCopyMethodHandler.cs
+++ b/MethodHandlers/WebDAVCopyMethodHandler.cs
@@ -88,7 +88,7 @@ namespace WebDAVSharp.Server.MethodHandlers
 
             destinationParentCollection.CopyItemHere(source, destinationName, copyContent);
 
-            context.SendSimpleResponse(isNew ? HttpStatusCode.Created : HttpStatusCode.NoContent);
+            context.SendSimpleResponse(isNew ? (int)HttpStatusCode.Created : (int)HttpStatusCode.NoContent);
         }
 
         #endregion

--- a/MethodHandlers/WebDAVCopyMethodHandler.cs
+++ b/MethodHandlers/WebDAVCopyMethodHandler.cs
@@ -13,6 +13,8 @@ namespace WebDAVSharp.Server.MethodHandlers
     /// </summary>
     internal class WebDavCopyMethodHandler : WebDavMethodHandlerBase, IWebDavMethodHandler
     {
+        #region Properties
+
         /// <summary>
         /// Gets the collection of the names of the HTTP methods handled by this instance.
         /// </summary>
@@ -29,6 +31,10 @@ namespace WebDAVSharp.Server.MethodHandlers
                 };
             }
         }
+
+        #endregion
+
+        #region Public Functions
 
         /// <summary>
         /// Processes the request.
@@ -84,5 +90,8 @@ namespace WebDAVSharp.Server.MethodHandlers
 
             context.SendSimpleResponse(isNew ? HttpStatusCode.Created : HttpStatusCode.NoContent);
         }
+
+        #endregion
+
     }
 }

--- a/MethodHandlers/WebDAVDeleteMethodHandler.cs
+++ b/MethodHandlers/WebDAVDeleteMethodHandler.cs
@@ -9,6 +9,9 @@ namespace WebDAVSharp.Server.MethodHandlers
     /// </summary>
     internal class WebDavDeleteMethodHandler : WebDavMethodHandlerBase, IWebDavMethodHandler
     {
+
+        #region Properties
+
         /// <summary>
         /// Gets the collection of the names of the HTTP methods handled by this instance.
         /// </summary>
@@ -25,6 +28,10 @@ namespace WebDAVSharp.Server.MethodHandlers
                 };
             }
         }
+
+        #endregion
+
+        #region Functions
 
         /// <summary>
         /// Processes the request.
@@ -46,5 +53,7 @@ namespace WebDAVSharp.Server.MethodHandlers
             collection.Delete(item);
             context.SendSimpleResponse();
         }
+
+        #endregion
     }
 }

--- a/MethodHandlers/WebDAVGetMethodHandler.cs
+++ b/MethodHandlers/WebDAVGetMethodHandler.cs
@@ -12,6 +12,9 @@ namespace WebDAVSharp.Server.MethodHandlers
     /// </summary>
     internal sealed class WebDavGetMethodHandler : WebDavMethodHandlerBase, IWebDavMethodHandler
     {
+
+        #region Properties
+
         /// <summary>
         /// Gets the collection of the names of the verbs handled by this instance.
         /// </summary>
@@ -28,6 +31,10 @@ namespace WebDAVSharp.Server.MethodHandlers
                 };
             }
         }
+
+        #endregion
+
+        #region Functions
 
         /// <summary>
         /// Processes the request.
@@ -73,5 +80,7 @@ namespace WebDAVSharp.Server.MethodHandlers
             }
             context.Response.Close();
         }
+
+        #endregion
     }
 }

--- a/MethodHandlers/WebDAVHeadMethodHandler.cs
+++ b/MethodHandlers/WebDAVHeadMethodHandler.cs
@@ -12,6 +12,8 @@ namespace WebDAVSharp.Server.MethodHandlers
     /// </summary>
     internal class WebDavHeadMethodHandler : WebDavMethodHandlerBase, IWebDavMethodHandler
     {
+
+        #region Properties
         /// <summary>
         /// Gets the collection of the names of the HTTP methods handled by this instance.
         /// </summary>
@@ -28,6 +30,10 @@ namespace WebDAVSharp.Server.MethodHandlers
                 };
             }
         }
+
+        #endregion
+
+        #region Functions
 
         /// <summary>
         /// Processes the request.
@@ -66,5 +72,8 @@ namespace WebDAVSharp.Server.MethodHandlers
 
             context.Response.Close();
         }
+
+        #endregion
+
     }
 }

--- a/MethodHandlers/WebDAVLockMethodHandler.cs
+++ b/MethodHandlers/WebDAVLockMethodHandler.cs
@@ -3,12 +3,15 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Security.Principal;
 using System.Text;
+using System.Threading;
 using System.Web;
 using System.Xml;
 using WebDAVSharp.Server.Adapters;
 using WebDAVSharp.Server.Exceptions;
 using WebDAVSharp.Server.Stores;
+using WebDAVSharp.Server.Stores.Locks;
 
 namespace WebDAVSharp.Server.MethodHandlers
 {
@@ -17,7 +20,7 @@ namespace WebDAVSharp.Server.MethodHandlers
     /// </summary>
     internal class WebDavLockMethodHandler : WebDavMethodHandlerBase, IWebDavMethodHandler
     {
-
+        
         #region Properties
 
         /// <summary>
@@ -52,6 +55,8 @@ namespace WebDAVSharp.Server.MethodHandlers
         /// <exception cref="WebDAVSharp.Server.Exceptions.WebDavPreconditionFailedException"></exception>
         public void ProcessRequest(WebDavServer server, IHttpListenerContext context, IWebDavStore store)
         {
+
+
             /***************************************************************************************************
              * Retreive al the information from the request
              ***************************************************************************************************/
@@ -59,26 +64,109 @@ namespace WebDAVSharp.Server.MethodHandlers
             // read the headers
             int depth = GetDepthHeader(context.Request);
             string timeout = GetTimeoutHeader(context.Request);
-
+            string locktoken = GetLockTokenIfHeader(context.Request);
+            int lockResult;
             // Initiate the XmlNamespaceManager and the XmlNodes
             XmlNamespaceManager manager;
-            XmlNode lockscopeNode, locktypeNode , ownerNode ;
+            XmlNode lockscopeNode, locktypeNode, ownerNode;
+            XmlDocument requestDocument = new XmlDocument();
 
-            // try to read the body
-            try
+            if (string.IsNullOrEmpty(locktoken))
             {
-                StreamReader reader = new StreamReader(context.Request.InputStream, Encoding.UTF8);
-                string requestBody = reader.ReadToEnd();
-
-                if (!requestBody.Equals("") && requestBody.Length != 0)
+                #region New Lock
+                // try to read the body
+                try
                 {
-                    XmlDocument requestDocument = new XmlDocument();
-                    requestDocument.LoadXml(requestBody);
+                    StreamReader reader = new StreamReader(context.Request.InputStream, Encoding.UTF8);
+                    string requestBody = reader.ReadToEnd();
 
-                    if (requestDocument.DocumentElement != null && requestDocument.DocumentElement.LocalName != "prop" &&
+                    if (!requestBody.Equals("") && requestBody.Length != 0)
+                    {
+
+                        requestDocument.LoadXml(requestBody);
+
+                        if (requestDocument.DocumentElement != null &&
+                            requestDocument.DocumentElement.LocalName != "prop" &&
+                            requestDocument.DocumentElement.LocalName != "lockinfo")
+                        {
+                            WebDavServer.Log.Debug("LOCK method without prop or lockinfo element in xml document");
+                        }
+
+                        manager = new XmlNamespaceManager(requestDocument.NameTable);
+                        manager.AddNamespace("D", "DAV:");
+                        manager.AddNamespace("Office", "schemas-microsoft-com:office:office");
+                        manager.AddNamespace("Repl", "http://schemas.microsoft.com/repl/");
+                        manager.AddNamespace("Z", "urn:schemas-microsoft-com:");
+
+                        // Get the lockscope, locktype and owner as XmlNodes from the XML document
+                        lockscopeNode = requestDocument.DocumentElement.SelectSingleNode("D:lockscope", manager);
+                        locktypeNode = requestDocument.DocumentElement.SelectSingleNode("D:locktype", manager);
+                        ownerNode = requestDocument.DocumentElement.SelectSingleNode("D:owner", manager);
+                    }
+                    else
+                    {
+                        throw new WebDavPreconditionFailedException();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    WebDavServer.Log.Warn(ex.Message);
+                    throw;
+                }
+
+
+                /***************************************************************************************************
+                * Lock the file or folder
+                ***************************************************************************************************/
+
+
+                // Get the parent collection of the item
+                IWebDavStoreCollection collection = GetParentCollection(server, store, context.Request.Url);
+
+                WebDavLockScope lockscope = (lockscopeNode.InnerXml.StartsWith("<D:exclusive"))
+                    ? WebDavLockScope.Exclusive
+                    : WebDavLockScope.Shared;
+
+                //Only lock available at this time is a Write Lock according to RFC
+                WebDavLockType locktype = (locktypeNode.InnerXml.StartsWith("<D:write")) ? WebDavLockType.Write : WebDavLockType.Write;
+
+                string lockuser = ownerNode.InnerText;
+
+                WindowsIdentity Identity = (WindowsIdentity)Thread.GetData(Thread.GetNamedDataSlot(WebDavServer.HttpUser));
+
+                lockResult = WebDavStoreItemLock.Lock(context.Request.Url, lockscope, locktype, Identity.Name, ref timeout,
+                    out locktoken, requestDocument, depth);
+
+                // Get the item from the collection
+                try
+                {
+                    GetItemFromCollection(collection, context.Request.Url);
+                }
+                catch (Exception)
+                {
+                    lockResult = (int)HttpStatusCode.Created;
+                }
+                #endregion
+            }
+            else
+            {
+                #region Refreshing a lock
+                //Refresh lock will ref us back the original XML document which was used to request this lock, from
+                //this we will grab the data we need to build the response to the lock refresh request.
+                lockResult = WebDavStoreItemLock.RefreshLock(context.Request.Url, locktoken, ref timeout, out requestDocument);
+                if (requestDocument == null)
+                {
+                    context.SendSimpleResponse(409);
+                    return;
+                }
+
+                try
+                {
+                    if (requestDocument.DocumentElement != null &&
+                        requestDocument.DocumentElement.LocalName != "prop" &&
                         requestDocument.DocumentElement.LocalName != "lockinfo")
                     {
-                      WebDavServer.Log.Debug("LOCK method without prop or lockinfo element in xml document");
+                        WebDavServer.Log.Debug("LOCK method without prop or lockinfo element in xml document");
                     }
 
                     manager = new XmlNamespaceManager(requestDocument.NameTable);
@@ -92,38 +180,14 @@ namespace WebDAVSharp.Server.MethodHandlers
                     locktypeNode = requestDocument.DocumentElement.SelectSingleNode("D:locktype", manager);
                     ownerNode = requestDocument.DocumentElement.SelectSingleNode("D:owner", manager);
                 }
-                else
+                catch (Exception ex)
                 {
-                    throw new WebDavPreconditionFailedException();
+                    WebDavServer.Log.Warn(ex.Message);
+                    throw;
                 }
-            }
-            catch (Exception ex)
-            {
-                WebDavServer.Log.Warn(ex.Message);
-                throw;
-            }
 
-            /***************************************************************************************************
-             * Lock the file or folder
-             ***************************************************************************************************/
-
-            bool isNew = false;
-
-            // Get the parent collection of the item
-            IWebDavStoreCollection collection = GetParentCollection(server, store, context.Request.Url);
-
-            try
-            {
-                // Get the item from the collection
-                GetItemFromCollection(collection, context.Request.Url);
+                #endregion
             }
-            catch (Exception)
-            {
-                collection.CreateDocument(context.Request.Url.Segments.Last().TrimEnd('/', '\\'));
-                isNew = true;
-            }
-           
-            
 
             /***************************************************************************************************
              * Create the body for the response
@@ -131,8 +195,7 @@ namespace WebDAVSharp.Server.MethodHandlers
 
             // Create the basic response XmlDocument
             XmlDocument responseDoc = new XmlDocument();
-            const string responseXml = "<?xml version=\"1.0\" encoding=\"utf-8\" ?><D:prop " +
-                                       "xmlns:D=\"DAV:\"><D:lockdiscovery><D:activelock/></D:lockdiscovery></D:prop>";
+            const string responseXml = "<?xml version=\"1.0\" encoding=\"utf-8\" ?><D:prop xmlns:D=\"DAV:\"><D:lockdiscovery><D:activelock/></D:lockdiscovery></D:prop>";
             responseDoc.LoadXml(responseXml);
 
             // Select the activelock XmlNode
@@ -146,41 +209,33 @@ namespace WebDAVSharp.Server.MethodHandlers
             // Add the additional elements, e.g. the header elements
 
             // The timeout element
-            WebDavProperty timeoutProperty = new WebDavProperty("timeout", timeout);
+            WebDavProperty timeoutProperty = new WebDavProperty("timeout", timeout);// timeout);
             activelock.AppendChild(timeoutProperty.ToXmlElement(responseDoc));
 
             // The depth element
             WebDavProperty depthProperty = new WebDavProperty("depth", (depth == 0 ? "0" : "Infinity"));
             activelock.AppendChild(depthProperty.ToXmlElement(responseDoc));
-            
+
             // The locktoken element
             WebDavProperty locktokenProperty = new WebDavProperty("locktoken", string.Empty);
             XmlElement locktokenElement = locktokenProperty.ToXmlElement(responseDoc);
-            WebDavProperty hrefProperty = new WebDavProperty("href", "opaquelocktoken:e71d4fae-5dec-22df-fea5-00a0c93bd5eb1");
+            WebDavProperty hrefProperty = new WebDavProperty("href", locktoken);//"opaquelocktoken:e71d4fae-5dec-22df-fea5-00a0c93bd5eb1");
             locktokenElement.AppendChild(hrefProperty.ToXmlElement(responseDoc));
+
+
             activelock.AppendChild(locktokenElement);
 
             /***************************************************************************************************
              * Send the response
              ***************************************************************************************************/
-            
+
             // convert the StringBuilder
             string resp = responseDoc.InnerXml;
             byte[] responseBytes = Encoding.UTF8.GetBytes(resp);
 
-            if (isNew)
-            {
-                // HttpStatusCode doesn't contain WebDav status codes, but HttpWorkerRequest can handle these WebDav status codes
-                context.Response.StatusCode = (int)HttpStatusCode.Created;
-                context.Response.StatusDescription = HttpWorkerRequest.GetStatusDescription((int)HttpStatusCode.Created);
-            }
-            else
-            {
-                // HttpStatusCode doesn't contain WebDav status codes, but HttpWorkerRequest can handle these WebDav status codes
-                context.Response.StatusCode = (int)HttpStatusCode.OK;
-                context.Response.StatusDescription = HttpWorkerRequest.GetStatusDescription((int)HttpStatusCode.OK);
-            }
-            
+
+            context.Response.StatusCode = lockResult;
+            context.Response.StatusDescription = HttpWorkerRequest.GetStatusDescription(lockResult);
 
             // set the headers of the response
             context.Response.ContentLength64 = responseBytes.Length;

--- a/MethodHandlers/WebDAVMethodHandlerBase.cs
+++ b/MethodHandlers/WebDAVMethodHandlerBase.cs
@@ -10,8 +10,15 @@ namespace WebDAVSharp.Server.MethodHandlers
     /// This is the base class for <see cref="IWebDavMethodHandler" /> implementations.
     /// </summary>
     internal abstract class WebDavMethodHandlerBase
-        {
+    {
+
+        #region Variables
+
         private const int DepthInfinity = -1;
+
+        #endregion
+
+        #region Static Functions
 
         /// <summary>
         /// Get the parent collection from the requested
@@ -159,5 +166,7 @@ namespace WebDAVSharp.Server.MethodHandlers
             // else, throw exception
             throw new WebDavConflictException();
         }
+
+        #endregion
     }
 }

--- a/MethodHandlers/WebDAVMethodHandlerBase.cs
+++ b/MethodHandlers/WebDAVMethodHandlerBase.cs
@@ -46,9 +46,9 @@ namespace WebDAVSharp.Server.MethodHandlers
             }
             catch (UnauthorizedAccessException)
             {
-                throw  new WebDavUnauthorizedException();
+                throw new WebDavUnauthorizedException();
             }
-            catch(WebDavNotFoundException)
+            catch (WebDavNotFoundException)
             {
                 throw new WebDavConflictException();
             }
@@ -129,6 +129,18 @@ namespace WebDAVSharp.Server.MethodHandlers
             // check if the string is valid and if it equals T
             return overwrite != null && overwrite.Equals("T");
             // else, return false
+        }
+
+        public static string GetLockTokenIfHeader(IHttpListenerRequest request)
+        {
+            //(<urn:uuid:cfdc70da-7feb-4bfe-8cb7-18f97d8fecb1>)
+            return request.Headers.AllKeys.Contains("If") ? request.Headers["If"].Substring(2, request.Headers["If"].Length-4) : string.Empty;
+        }
+        public static string GetLockTokenHeader(IHttpListenerRequest request)
+        {
+            if (!request.Headers.AllKeys.Contains("Lock-Token")) return string.Empty;
+            string token = request.Headers["Lock-Token"];
+            return (token.Substring(1, token.Length - 2));
         }
 
         /// <summary>

--- a/MethodHandlers/WebDAVMethodHandlers.cs
+++ b/MethodHandlers/WebDAVMethodHandlers.cs
@@ -10,6 +10,8 @@ namespace WebDAVSharp.Server.MethodHandlers
     /// </summary>
     internal static class WebDavMethodHandlers
     {
+        #region Properties
+
         private static readonly List<IWebDavMethodHandler> _BuiltIn = new List<IWebDavMethodHandler>();
 
         /// <summary>
@@ -30,6 +32,9 @@ namespace WebDAVSharp.Server.MethodHandlers
             }
         }
 
+        #endregion
+
+        #region Static Functions
         /// <summary>
         /// Scans the WebDAV# assemblies for known <see cref="IWebDavMethodHandler"/>
         /// types.
@@ -47,5 +52,7 @@ namespace WebDAVSharp.Server.MethodHandlers
 
             _BuiltIn.AddRange(methodHandlerInstances);
         }
+
+        #endregion
     }
 }

--- a/MethodHandlers/WebDAVMkColMethodHandler.cs
+++ b/MethodHandlers/WebDAVMkColMethodHandler.cs
@@ -13,6 +13,7 @@ namespace WebDAVSharp.Server.MethodHandlers
     /// </summary>
     internal class WebDavMkColMethodHandler : WebDavMethodHandlerBase, IWebDavMethodHandler
     {
+        #region Properties
         /// <summary>
         /// Gets the collection of the names of the HTTP methods handled by this instance.
         /// </summary>
@@ -29,6 +30,10 @@ namespace WebDAVSharp.Server.MethodHandlers
                 };
             }
         }
+
+        #endregion
+
+        #region Functions
 
         /// <summary>
         /// Processes the request.
@@ -57,5 +62,7 @@ namespace WebDAVSharp.Server.MethodHandlers
 
             context.SendSimpleResponse(HttpStatusCode.Created);
         }
+
+        #endregion
     }
 }

--- a/MethodHandlers/WebDAVMkColMethodHandler.cs
+++ b/MethodHandlers/WebDAVMkColMethodHandler.cs
@@ -60,7 +60,7 @@ namespace WebDAVSharp.Server.MethodHandlers
 
             collection.CreateCollection(collectionName);
 
-            context.SendSimpleResponse(HttpStatusCode.Created);
+            context.SendSimpleResponse((int)HttpStatusCode.Created);
         }
 
         #endregion

--- a/MethodHandlers/WebDAVMoveMethodHandler.cs
+++ b/MethodHandlers/WebDAVMoveMethodHandler.cs
@@ -13,6 +13,7 @@ namespace WebDAVSharp.Server.MethodHandlers
     /// </summary>
     internal class WebDavMoveMethodHandler : WebDavMethodHandlerBase, IWebDavMethodHandler
     {
+        #region Properties
         /// <summary>
         /// Gets the collection of the names of the HTTP methods handled by this instance.
         /// </summary>
@@ -30,6 +31,10 @@ namespace WebDAVSharp.Server.MethodHandlers
             }
         }
 
+        #endregion
+
+        #region Functions
+
         /// <summary>
         /// Processes the request.
         /// </summary>
@@ -40,7 +45,7 @@ namespace WebDAVSharp.Server.MethodHandlers
         /// <param name="store">The <see cref="IWebDavStore" /> that the <see cref="WebDavServer" /> is hosting.</param>
         public void ProcessRequest(WebDavServer server, IHttpListenerContext context, IWebDavStore store)
         {
-            var source = context.Request.Url.GetItem(server, store);
+            IWebDavStoreItem source = context.Request.Url.GetItem(server, store);
 
             MoveItem(server, context, store, source);
         }
@@ -56,7 +61,7 @@ namespace WebDAVSharp.Server.MethodHandlers
         /// <param name="sourceWebDavStoreItem">The <see cref="IWebDavStoreItem" /> that will be moved</param>
         /// <exception cref="WebDAVSharp.Server.Exceptions.WebDavForbiddenException">If the source path is the same as the destination path</exception>
         /// <exception cref="WebDAVSharp.Server.Exceptions.WebDavPreconditionFailedException">If one of the preconditions failed</exception>
-        private void MoveItem(WebDavServer server, IHttpListenerContext context, IWebDavStore store,
+        private static void MoveItem(WebDavServer server, IHttpListenerContext context, IWebDavStore store,
             IWebDavStoreItem sourceWebDavStoreItem)
         {
             Uri destinationUri = GetDestinationHeader(context.Request);
@@ -83,5 +88,7 @@ namespace WebDAVSharp.Server.MethodHandlers
             // send correct response
             context.SendSimpleResponse(isNew ? HttpStatusCode.Created : HttpStatusCode.NoContent);
         }
+
+        #endregion
     }
 }

--- a/MethodHandlers/WebDAVMoveMethodHandler.cs
+++ b/MethodHandlers/WebDAVMoveMethodHandler.cs
@@ -86,7 +86,7 @@ namespace WebDAVSharp.Server.MethodHandlers
             destinationParentCollection.MoveItemHere(sourceWebDavStoreItem, destinationName);
 
             // send correct response
-            context.SendSimpleResponse(isNew ? HttpStatusCode.Created : HttpStatusCode.NoContent);
+            context.SendSimpleResponse(isNew ? (int)HttpStatusCode.Created : (int)HttpStatusCode.NoContent);
         }
 
         #endregion

--- a/MethodHandlers/WebDAVOptionsMethodHandler.cs
+++ b/MethodHandlers/WebDAVOptionsMethodHandler.cs
@@ -9,6 +9,16 @@ namespace WebDAVSharp.Server.MethodHandlers
     /// </summary>
     internal class WebDavOptionsMethodHandler : WebDavMethodHandlerBase, IWebDavMethodHandler
     {
+        #region Variables
+
+        private static readonly List<string> verbsAllowed = new List<string> { "OPTIONS", "TRACE", "GET", "HEAD", "POST", "COPY", "PROPFIND", "LOCK", "UNLOCK" };
+
+        private static readonly List<string> verbsPublic = new List<string> { "OPTIONS", "GET", "HEAD", "PROPFIND", "PROPPATCH", "MKCOL", "PUT", "DELETE", "COPY", "MOVE", "LOCK", "UNLOCK" };
+
+        #endregion
+
+        #region Properties
+
         /// <summary>
         /// Gets the collection of the names of the HTTP methods handled by this instance.
         /// </summary>
@@ -23,6 +33,9 @@ namespace WebDAVSharp.Server.MethodHandlers
             }
         }
 
+        #endregion
+
+        #region Functions
         /// <summary>
         /// Processes the request.
         /// </summary>
@@ -33,9 +46,6 @@ namespace WebDAVSharp.Server.MethodHandlers
         /// <param name="store">The <see cref="IWebDavStore" /> that the <see cref="WebDavServer" /> is hosting.</param>
         public void ProcessRequest(WebDavServer server, IHttpListenerContext context, IWebDavStore store)
         {
-            List<string> verbsAllowed = new List<string> { "OPTIONS", "TRACE", "GET", "HEAD", "POST", "COPY", "PROPFIND", "LOCK", "UNLOCK" };
-
-            List<string> verbsPublic = new List<string> { "OPTIONS", "GET", "HEAD", "PROPFIND", "PROPPATCH", "MKCOL", "PUT", "DELETE", "COPY", "MOVE", "LOCK", "UNLOCK" };
 
             foreach (string verb in verbsAllowed)
                 context.Response.AppendHeader("Allow", verb);
@@ -46,5 +56,7 @@ namespace WebDAVSharp.Server.MethodHandlers
             // Sends 200 OK
             context.SendSimpleResponse();
         }
+
+        #endregion
     }
 }

--- a/MethodHandlers/WebDAVProppatchMethodHandler.cs
+++ b/MethodHandlers/WebDAVProppatchMethodHandler.cs
@@ -17,6 +17,8 @@ namespace WebDAVSharp.Server.MethodHandlers
     /// </summary>
     internal class WebDavProppatchMethodHandler : WebDavMethodHandlerBase, IWebDavMethodHandler
     {
+
+        #region Properties
         /// <summary>
         /// Gets the collection of the names of the HTTP methods handled by this instance.
         /// </summary>
@@ -34,6 +36,10 @@ namespace WebDAVSharp.Server.MethodHandlers
             }
         }
 
+        #endregion
+
+        #region Functions
+
         /// <summary>
         /// Processes the request.
         /// </summary>
@@ -44,8 +50,6 @@ namespace WebDAVSharp.Server.MethodHandlers
         /// <param name="store">The <see cref="IWebDavStore" /> that the <see cref="WebDavServer" /> is hosting.</param>
         public void ProcessRequest(WebDavServer server, IHttpListenerContext context, IWebDavStore store)
         {
-            ILog log = LogManager.GetCurrentClassLogger();
-
             /***************************************************************************************************
              * Retreive al the information from the request
              ***************************************************************************************************/
@@ -72,7 +76,7 @@ namespace WebDAVSharp.Server.MethodHandlers
                     {
                         if (requestDocument.DocumentElement.LocalName != "propertyupdate")
                         {
-                            log.Debug("PROPPATCH method without propertyupdate element in xml document");
+                            WebDavServer.Log.Debug("PROPPATCH method without propertyupdate element in xml document");
                         }
 
                         manager = new XmlNamespaceManager(requestDocument.NameTable);
@@ -87,7 +91,7 @@ namespace WebDAVSharp.Server.MethodHandlers
             }
             catch (Exception ex)
             {
-                log.Warn(ex.Message);
+                WebDavServer.Log.Warn(ex.Message);
             }
 
             /***************************************************************************************************
@@ -118,6 +122,7 @@ namespace WebDAVSharp.Server.MethodHandlers
                             fileInfo.LastWriteTime = Convert.ToDateTime(node.InnerText).ToUniversalTime();
                             break;
                         case "Win32FileAttributes":
+                            //todo Win32FileAttributes
                             //fileInfo.Attributes = 
                             //fileInfo.Attributes = Convert.ToDateTime(node.InnerText);
                             break;
@@ -147,7 +152,7 @@ namespace WebDAVSharp.Server.MethodHandlers
             responseNode.AppendChild(hrefProperty.ToXmlElement(responseDoc));
 
             // The propstat element
-            WebDavProperty propstatProperty = new WebDavProperty("propstat", "");
+            WebDavProperty propstatProperty = new WebDavProperty("propstat", string.Empty);
             XmlElement propstatElement = propstatProperty.ToXmlElement(responseDoc);
 
             // The propstat/status element
@@ -163,9 +168,9 @@ namespace WebDAVSharp.Server.MethodHandlers
                             .Contains("lastaccesstime") || child.Name.ToLower()
                                 .Contains("lastmodifiedtime")
                 let node = propNode.SelectSingleNode(child.Name, manager)
-                select node != null
-                    ? new WebDavProperty(child.LocalName, "", node.NamespaceURI)
-                    : new WebDavProperty(child.LocalName, "", ""))
+
+                select new WebDavProperty(child.LocalName, string.Empty, node != null ? node.NamespaceURI : string.Empty))
+
                 propstatElement.AppendChild(property.ToXmlElement(responseDoc));
 
             responseNode.AppendChild(propstatElement);
@@ -192,5 +197,8 @@ namespace WebDAVSharp.Server.MethodHandlers
 
             context.Response.Close();
         }
+
+        #endregion
+
     }
 }

--- a/MethodHandlers/WebDAVPutMethodHandler.cs
+++ b/MethodHandlers/WebDAVPutMethodHandler.cs
@@ -85,7 +85,7 @@ namespace WebDAVSharp.Server.MethodHandlers
                 }
             }
 
-            context.SendSimpleResponse(HttpStatusCode.Created);
+            context.SendSimpleResponse((int)HttpStatusCode.Created);
         }
 
         #endregion

--- a/MethodHandlers/WebDAVPutMethodHandler.cs
+++ b/MethodHandlers/WebDAVPutMethodHandler.cs
@@ -14,6 +14,8 @@ namespace WebDAVSharp.Server.MethodHandlers
     /// </summary>
     internal class WebDavPutMethodHandler : WebDavMethodHandlerBase, IWebDavMethodHandler
     {
+        #region Properties
+
         /// <summary>
         /// Gets the collection of the names of the HTTP methods handled by this instance.
         /// </summary>
@@ -30,6 +32,10 @@ namespace WebDAVSharp.Server.MethodHandlers
                 };
             }
         }
+
+        #endregion
+
+        #region Functions
 
         /// <summary>
         /// Processes the request.
@@ -81,5 +87,7 @@ namespace WebDAVSharp.Server.MethodHandlers
 
             context.SendSimpleResponse(HttpStatusCode.Created);
         }
+
+        #endregion
     }
 }

--- a/MethodHandlers/WebDAVUnlockMethodHandler.cs
+++ b/MethodHandlers/WebDAVUnlockMethodHandler.cs
@@ -10,6 +10,9 @@ namespace WebDAVSharp.Server.MethodHandlers
     /// </summary>
     internal class WebDavUnlockMethodHandler : WebDavMethodHandlerBase, IWebDavMethodHandler
     {
+
+        #region Properties
+
         /// <summary>
         /// Gets the collection of the names of the HTTP methods handled by this instance.
         /// </summary>
@@ -27,6 +30,9 @@ namespace WebDAVSharp.Server.MethodHandlers
             }
         }
 
+        #endregion
+
+        #region Functions
         /// <summary>
         /// Processes the request.
         /// </summary>
@@ -49,5 +55,8 @@ namespace WebDAVSharp.Server.MethodHandlers
 
             context.SendSimpleResponse(HttpStatusCode.NoContent);
         }
+
+        #endregion
+
     }
 }

--- a/MethodHandlers/WebDAVUnlockMethodHandler.cs
+++ b/MethodHandlers/WebDAVUnlockMethodHandler.cs
@@ -1,7 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Net;
+using System.Security.Principal;
+using System.Text;
+using System.Threading;
 using WebDAVSharp.Server.Adapters;
 using WebDAVSharp.Server.Stores;
+using WebDAVSharp.Server.Stores.Locks;
 
 namespace WebDAVSharp.Server.MethodHandlers
 {
@@ -43,17 +48,11 @@ namespace WebDAVSharp.Server.MethodHandlers
         /// <param name="store">The <see cref="IWebDavStore" /> that the <see cref="WebDavServer" /> is hosting.</param>
         public void ProcessRequest(WebDavServer server, IHttpListenerContext context, IWebDavStore store)
         {
-            // Get the parent collection of the item
-            IWebDavStoreCollection collection = GetParentCollection(server, store, context.Request.Url);
-
-            // Get the item from the collection
-            IWebDavStoreItem item = GetItemFromCollection(collection, context.Request.Url);
-
             /***************************************************************************************************
             * Send the response
             ***************************************************************************************************/
-
-            context.SendSimpleResponse(HttpStatusCode.NoContent);
+            WindowsIdentity Identity = (WindowsIdentity)Thread.GetData(Thread.GetNamedDataSlot(WebDavServer.HttpUser));
+            context.SendSimpleResponse(WebDavStoreItemLock.UnLock(context.Request.Url, GetLockTokenHeader(context.Request), Identity.Name));
         }
 
         #endregion

--- a/Stores/BaseClasses/WebDAVStoreBase.cs
+++ b/Stores/BaseClasses/WebDAVStoreBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 
 namespace WebDAVSharp.Server.Stores.BaseClasses
 {
@@ -11,7 +12,7 @@ namespace WebDAVSharp.Server.Stores.BaseClasses
         #region Variables
 
         private readonly IWebDavStoreCollection _root;
-
+        
         #endregion
 
         #region Constructor

--- a/Stores/BaseClasses/WebDAVStoreBase.cs
+++ b/Stores/BaseClasses/WebDAVStoreBase.cs
@@ -7,7 +7,14 @@ namespace WebDAVSharp.Server.Stores.BaseClasses
     /// </summary>
     public abstract class WebDavStoreBase : IWebDavStore
     {
+
+        #region Variables
+
         private readonly IWebDavStoreCollection _root;
+
+        #endregion
+
+        #region Constructor
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WebDavStoreBase" /> class.
@@ -23,7 +30,9 @@ namespace WebDAVSharp.Server.Stores.BaseClasses
             _root = root;
         }
 
-        #region IWebDAVStore Members
+        #endregion
+
+        #region Properties
 
         /// <summary>
         /// Gets the root collection of this <see cref="IWebDavStore" />.
@@ -37,5 +46,6 @@ namespace WebDAVSharp.Server.Stores.BaseClasses
         }
 
         #endregion
+
     }
 }

--- a/Stores/BaseClasses/WebDAVStoreDocumentBase.cs
+++ b/Stores/BaseClasses/WebDAVStoreDocumentBase.cs
@@ -8,6 +8,8 @@ namespace WebDAVSharp.Server.Stores.BaseClasses
     /// </summary>
     public class WebDavStoreDocumentBase : WebDavStoreItemBase
     {
+
+        #region Constructor
         /// <summary>
         /// Initializes a new instance of the <see cref="WebDavStoreItemBase" /> class.
         /// </summary>
@@ -18,7 +20,9 @@ namespace WebDAVSharp.Server.Stores.BaseClasses
         {
         }
 
-        #region IWebDAVStoreItem Members
+        #endregion
+
+        #region Properties
 
         /// <summary>
         /// Gets or sets the mime type of this <see cref="IWebDavStoreItem" />.
@@ -35,5 +39,6 @@ namespace WebDAVSharp.Server.Stores.BaseClasses
         }
 
         #endregion
+
     }
 }

--- a/Stores/BaseClasses/WebDAVStoreItemBase.cs
+++ b/Stores/BaseClasses/WebDAVStoreItemBase.cs
@@ -8,9 +8,14 @@ namespace WebDAVSharp.Server.Stores.BaseClasses
     /// </summary>
     public class WebDavStoreItemBase : IWebDavStoreItem
     {
+        #region Variables
+
         private readonly IWebDavStoreCollection _parentCollection;
         private string _name;
 
+        #endregion
+
+        #region Constuctor
         /// <summary>
         /// Initializes a new instance of the <see cref="WebDavStoreItemBase" /> class.
         /// </summary>
@@ -27,7 +32,9 @@ namespace WebDAVSharp.Server.Stores.BaseClasses
             _name = name;
         }
 
-        #region IWebDAVStoreItem Members
+        #endregion
+
+        #region Properties
 
         /// <summary>
         /// Gets the parent <see cref="IWebDavStoreCollection" /> that owns this <see cref="IWebDavStoreItem" />.
@@ -117,6 +124,8 @@ namespace WebDAVSharp.Server.Stores.BaseClasses
 
         #endregion
 
+        #region Functions
+
         /// <summary>
         /// Called before the name of this <see cref="IWebDavStoreItem" /> is changing.
         /// </summary>
@@ -140,5 +149,7 @@ namespace WebDAVSharp.Server.Stores.BaseClasses
         protected virtual void OnNameChanged(string oldName, string newName)
         {
         }
+
+        #endregion
     }
 }

--- a/Stores/BaseClasses/WebDAVStoreItemBase.cs
+++ b/Stores/BaseClasses/WebDAVStoreItemBase.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Net;
+using System.Runtime.InteropServices;
 using WebDAVSharp.Server.Exceptions;
+using WebDAVSharp.Server.Stores.Locks;
 
 namespace WebDAVSharp.Server.Stores.BaseClasses
 {
@@ -61,7 +64,8 @@ namespace WebDAVSharp.Server.Stores.BaseClasses
             set
             {
                 string fixedName = (value ?? string.Empty).Trim();
-                if (fixedName == _name) return;
+                if (fixedName == _name)
+                    return;
                 if (!OnNameChanging(_name, fixedName))
                     throw new WebDavForbiddenException();
                 string oldName = _name;
@@ -97,7 +101,10 @@ namespace WebDAVSharp.Server.Stores.BaseClasses
         /// </summary>
         public virtual string ItemPath
         {
-            get { return String.Empty; }
+            get
+            {
+                return String.Empty;
+            }
         }
 
         /// <summary>
@@ -150,6 +157,6 @@ namespace WebDAVSharp.Server.Stores.BaseClasses
         {
         }
 
-        #endregion
+      #endregion
     }
 }

--- a/Stores/DiskStore/WebDAVDiskStore.cs
+++ b/Stores/DiskStore/WebDAVDiskStore.cs
@@ -10,8 +10,14 @@ namespace WebDAVSharp.Server.Stores.DiskStore
     [DebuggerDisplay("Disk Store ({RootPath})")]
     public sealed class WebDavDiskStore : IWebDavStore
     {
+
+        #region Variables
+
         private readonly string _rootPath;
 
+        #endregion
+
+        #region Constructor
         /// <summary>
         /// Initializes a new instance of the <see cref="WebDavDiskStore" /> class.
         /// </summary>
@@ -23,13 +29,16 @@ namespace WebDAVSharp.Server.Stores.DiskStore
         public WebDavDiskStore(string rootPath)
         {
             if (rootPath == null)
-                throw new ArgumentNullException(rootPath);
+                throw new ArgumentNullException("rootPath");
             if (!Directory.Exists(rootPath))
                 throw new DirectoryNotFoundException(rootPath);
 
             _rootPath = rootPath;
         }
 
+        #endregion
+
+        #region Properties
         /// <summary>
         /// Gets the root path for the folder that is hosted in this <see cref="WebDavDiskStore" />.
         /// </summary>
@@ -44,8 +53,6 @@ namespace WebDAVSharp.Server.Stores.DiskStore
             }
         }
 
-        #region IWebDAVStore Members
-
         /// <summary>
         /// Gets the root collection of this <see cref="IWebDavStore" />.
         /// </summary>
@@ -58,5 +65,6 @@ namespace WebDAVSharp.Server.Stores.DiskStore
         }
 
         #endregion
+
     }
 }

--- a/Stores/DiskStore/WebDAVDiskStoreDocument.cs
+++ b/Stores/DiskStore/WebDAVDiskStoreDocument.cs
@@ -14,6 +14,8 @@ namespace WebDAVSharp.Server.Stores.DiskStore
     [DebuggerDisplay("File ({Name})")]
     public sealed class WebDavDiskStoreDocument : WebDavDiskStoreItem, IWebDavStoreDocument
     {
+        #region Constructor
+
         /// <summary>
         /// Initializes a new instance of the <see cref="WebDavDiskStoreDocument" /> class.
         /// </summary>
@@ -31,7 +33,9 @@ namespace WebDAVSharp.Server.Stores.DiskStore
             // Do nothing here
         }
 
-        #region IWebDAVStoreDocument Members
+        #endregion
+
+        #region Functions
 
         /// <summary>
         /// Gets the size of the document in bytes.
@@ -66,11 +70,6 @@ namespace WebDAVSharp.Server.Stores.DiskStore
                 return Md5Util.Md5HashStringForUtf8String(ItemPath + ModificationDate + Hidden + Size);
             }
         }
-
-
-        #endregion
-
-        #region IWebDAVStoreDocument Members
 
         /// <summary>
         /// Opens a <see cref="Stream" /> object for the document, in read-only mode.

--- a/Stores/DiskStore/WebDAVDiskStoreItem.cs
+++ b/Stores/DiskStore/WebDAVDiskStoreItem.cs
@@ -17,17 +17,19 @@ namespace WebDAVSharp.Server.Stores.DiskStore
     /// </summary>
     public class WebDavDiskStoreItem : WebDavStoreItemBase
     {
+
+        #region Variables
+
         /// <summary>
         /// Gets the Identity of the person logged on via HTTP Request.
         /// </summary>
         protected readonly WindowsIdentity Identity;
 
-        /// <summary>
-        /// Log
-        /// </summary>
-        protected ILog Log;
-        private readonly WebDavDiskStoreCollection _parentCollection;
         private readonly string _path;
+
+        #endregion
+
+        #region Constructor
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WebDavDiskStoreItem" /> class.
@@ -45,12 +47,13 @@ namespace WebDAVSharp.Server.Stores.DiskStore
         {
             if (String.IsNullOrWhiteSpace(path))
                 throw new ArgumentNullException("path");
-
-            _parentCollection = parentCollection;
             _path = path;
             Identity = (WindowsIdentity)Thread.GetData(Thread.GetNamedDataSlot(WebDavServer.HttpUser));
-            Log = LogManager.GetCurrentClassLogger();
         }
+
+        #endregion
+
+        #region Properties
 
         /// <summary>
         /// Gets the path to this <see cref="WebDavDiskStoreItem" />.
@@ -62,9 +65,7 @@ namespace WebDAVSharp.Server.Stores.DiskStore
                 return _path;
             }
         }
-
-        #region IWebDAVStoreItem Members
-
+        
         /// <summary>
         /// Gets or sets the name of this <see cref="IWebDavStoreItem" />.
         /// </summary>

--- a/Stores/DiskStore/WebDAVDiskStoreItem.cs
+++ b/Stores/DiskStore/WebDAVDiskStoreItem.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Security.Principal;
 using System.Threading;
-using Common.Logging;
 using WebDAVSharp.Server.Stores.BaseClasses;
 
 namespace WebDAVSharp.Server.Stores.DiskStore
@@ -43,12 +42,15 @@ namespace WebDAVSharp.Server.Stores.DiskStore
         /// <param name="path">The path that this <see cref="WebDavDiskStoreItem" /> maps to.</param>
         /// <exception cref="System.ArgumentNullException">path</exception>
         /// <exception cref="ArgumentNullException"><paramref name="path" /> is <c>null</c> or empty.</exception>
-        protected WebDavDiskStoreItem(WebDavDiskStoreCollection parentCollection, string path) : base(parentCollection, path)
+        protected WebDavDiskStoreItem(WebDavDiskStoreCollection parentCollection, string path)
+            : base(parentCollection, path)
         {
             if (String.IsNullOrWhiteSpace(path))
                 throw new ArgumentNullException("path");
             _path = path;
+
             Identity = (WindowsIdentity)Thread.GetData(Thread.GetNamedDataSlot(WebDavServer.HttpUser));
+            
         }
 
         #endregion
@@ -65,7 +67,7 @@ namespace WebDAVSharp.Server.Stores.DiskStore
                 return _path;
             }
         }
-        
+
         /// <summary>
         /// Gets or sets the name of this <see cref="IWebDavStoreItem" />.
         /// </summary>
@@ -138,5 +140,8 @@ namespace WebDAVSharp.Server.Stores.DiskStore
         }
 
         #endregion
+
+
+        
     }
 }

--- a/Stores/IWebDAVStoreItem.cs
+++ b/Stores/IWebDAVStoreItem.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Net;
+using System.Runtime.InteropServices;
+using WebDAVSharp.Server.Stores.Locks;
 
 namespace WebDAVSharp.Server.Stores
 {
@@ -88,5 +91,7 @@ namespace WebDAVSharp.Server.Stores
         {
             get;
         }
+
+        
     }
 }

--- a/Stores/Locks/WebDavLockScope.cs
+++ b/Stores/Locks/WebDavLockScope.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WebDAVSharp.Server.Stores.Locks
+{
+    /// <summary>
+    /// Possible scopes for locks.
+    /// </summary>
+    public enum WebDavLockScope
+    {
+        /// <summary>
+        /// Can only have one exclusive Lock
+        /// </summary>
+        Exclusive,
+
+        /// <summary>
+        /// Can be many.
+        /// </summary>
+        Shared
+    }
+}

--- a/Stores/Locks/WebDavLockType.cs
+++ b/Stores/Locks/WebDavLockType.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WebDAVSharp.Server.Stores.Locks
+{
+    /// <summary>
+    /// Specifies the access type of a lock. At present, this specification only defines one lock type, the write lock.
+    /// </summary>
+    public enum WebDavLockType
+    {
+        /// <summary>
+        /// A Write Lock type
+        /// </summary>
+        Write,
+    }
+}

--- a/Stores/Locks/WebDavStoreItemLock.cs
+++ b/Stores/Locks/WebDavStoreItemLock.cs
@@ -1,0 +1,227 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Xml;
+
+
+namespace WebDAVSharp.Server.Stores.Locks
+{
+    /// <summary>
+    /// This class provides the locking functionality.
+    /// 
+    /// </summary>
+    public class WebDavStoreItemLock
+    {
+
+        #region Variables
+        /// <summary>
+        /// Allow Objects to be checked out forever
+        /// </summary>
+        internal static bool AllowInfiniteCheckouts = false;
+
+        /// <summary>
+        /// Max amount of seconds a item can be checkout for.
+        /// </summary>
+        internal static long MaxCheckOutSeconds = long.MaxValue;
+
+        /// <summary>
+        /// Used to store the locks per URI
+        /// </summary>
+        private static readonly Dictionary<Uri, List<WebDaveStoreItemLockInstance>> ObjectLocks = new Dictionary<Uri, List<WebDaveStoreItemLockInstance>>();
+
+        #endregion
+
+        /// <summary>
+        /// This function removes any expired locks for the path.
+        /// </summary>
+        /// <param name="path"></param>
+        private static void CleanLocks(Uri path)
+        {
+            lock (ObjectLocks)
+            {
+                if (!ObjectLocks.ContainsKey(path))
+                    return;
+                foreach (
+                    WebDaveStoreItemLockInstance ilock in ObjectLocks[path].ToList()
+                        .Where(ilock => ilock.ExpirationDate != null && (DateTime)ilock.ExpirationDate < DateTime.Now)
+                    )
+                    ObjectLocks[path].Remove(ilock);
+            }
+        }
+
+        /// <summary>
+        /// This function will refresh an existing lock.
+        /// </summary>
+        /// <param name="path">Target URI to the file or folder </param>
+        /// <param name="locktoken">The token issued when the lock was established</param>
+        /// <param name="requestedlocktimeout">The requested timeout</param>
+        /// <param name="requestDocument">Output parameter, returns the Request document that was used when the lock was established.</param>
+        /// <returns></returns>
+        public static int RefreshLock(Uri path, string locktoken, ref string requestedlocktimeout,
+            out XmlDocument requestDocument)
+        {
+            CleanLocks(path);
+            //Refreshing an existing lock
+
+            //If a lock doesn't exist then lets just reply with a Precondition Failed.
+            //412 (Precondition Failed), with 'lock-token-matches-request-uri' precondition code - The LOCK request was 
+            //made with an If header, indicating that the client wishes to refresh the given lock. However, the Request-URI 
+            //did not fall within the scope of the lock identified by the token. The lock may have a scope that does not 
+            //include the Request-URI, or the lock could have disappeared, or the token may be invalid.
+            requestDocument = null;
+            if (!ObjectLocks.ContainsKey(path))
+                return 412;
+
+            string tmptoken = locktoken;
+            lock (ObjectLocks)
+            {
+                WebDaveStoreItemLockInstance ilock = ObjectLocks[path].FirstOrDefault(d => (d.Token == tmptoken));
+                if (ilock == null)
+                {
+                    WebDavServer.Log.Debug("Lock Refresh Failed , Lock does not exist.");
+                    return 412;
+                }
+                WebDavServer.Log.Debug("Lock Refresh Successful.");
+                ilock.RefreshLock(ref requestedlocktimeout);
+                requestDocument = ilock.RequestDocument;
+
+                return (int)HttpStatusCode.OK;
+            }
+        }
+
+        /// <summary>
+        /// Locks the request Path.
+        /// </summary>
+        /// <param name="path">URI to the item to be locked</param>
+        /// <param name="lockscope">The lock Scope used for locking</param>
+        /// <param name="locktype">The lock Type used for locking</param>
+        /// <param name="lockowner">The owner of the lock</param>
+        /// <param name="requestedlocktimeout">The requested timeout</param>
+        /// <param name="locktoken">Out parameter, returns the issued token</param>
+        /// <param name="requestDocument">the Request Document</param>
+        /// <param name="depth">How deep to lock, 0,1, or infinity</param>
+        /// <returns></returns>
+        public static int Lock(Uri path, WebDavLockScope lockscope, WebDavLockType locktype, string lockowner,
+            ref string requestedlocktimeout, out string locktoken, XmlDocument requestDocument, int depth)
+        {
+            CleanLocks(path);
+            WebDavServer.Log.Info("Lock Requested Timeout:" + requestedlocktimeout);
+            locktoken = string.Empty;
+            lock (ObjectLocks)
+            {
+                /*
+            The table below describes the behavior that occurs when a lock request is made on a resource.
+            Current State   Shared Lock OK      Exclusive Lock OK
+            None	            True	            True
+            Shared Lock     	True            	False
+            Exclusive Lock	    False	            False*
+
+            Legend: True = lock may be granted. False = lock MUST NOT be granted. *=It is illegal for a principal to request the same lock twice.
+
+            The current lock state of a resource is given in the leftmost column, and lock requests are listed in the first row. The intersection of a row and column gives the result of a lock request. For example, if a shared lock is held on a resource, and an exclusive lock is requested, the table entry is "false", indicating that the lock must not be granted.            
+             */
+
+
+                //if ObjectLocks doesn't contain the path, then this is a new lock and regardless
+                //of whether it is Exclusive or Shared it is successful.
+                if (!ObjectLocks.ContainsKey(path))
+                {
+                    ObjectLocks.Add(path, new List<WebDaveStoreItemLockInstance>());
+
+                    ObjectLocks[path].Add(new WebDaveStoreItemLockInstance(path, lockscope, locktype, lockowner,
+                        ref requestedlocktimeout, ref locktoken,
+                        requestDocument, depth));
+
+                    WebDavServer.Log.Debug("Created New Lock (" + lockscope + "), URI had no locks.  Timeout:" +
+                                           requestedlocktimeout);
+
+                    return (int)HttpStatusCode.OK;
+                }
+
+                //The fact that ObjectLocks contains this URI means that there is already a lock on this object,
+                //This means the lock fails because you can only have 1 exclusive lock.
+                if (lockscope == WebDavLockScope.Exclusive)
+                {
+                    WebDavServer.Log.Debug("Lock Creation Failed (Exclusive), URI already has a lock.");
+                    return 423;
+                }
+
+                //If the scope is shared and all other locks on this uri are shared we are ok, otherwise we fail.
+                if (lockscope == WebDavLockScope.Shared)
+                    if (ObjectLocks[path].Any(itemLock => itemLock.LockScope == WebDavLockScope.Exclusive))
+                    {
+                        WebDavServer.Log.Debug("Lock Creation Failed (Shared), URI has exclusive lock.");
+                        return 423;
+                    }
+                //423 (Locked), potentially with 'no-conflicting-lock' precondition code - 
+                //There is already a lock on the resource that is not compatible with the 
+                //requested lock (see lock compatibility table above).
+
+                //If it gets to here, then we are most likely creating another shared lock on the file.
+
+                #region Create New Lock
+
+                ObjectLocks[path].Add(new WebDaveStoreItemLockInstance(path, lockscope, locktype, lockowner,
+                    ref requestedlocktimeout, ref locktoken,
+                    requestDocument, depth));
+
+                WebDavServer.Log.Debug("Created New Lock (" + lockscope + "), URI had no locks.  Timeout:" +
+                                       requestedlocktimeout);
+
+                #endregion
+
+                return (int)HttpStatusCode.OK;
+            }
+        }
+
+        /// <summary>
+        /// Unlocks the URI passed if the token matches a lock token in use.
+        /// </summary>
+        /// <param name="path">URI to resource</param>
+        /// <param name="locktoken">Token used to lock.</param>
+        /// <param name="owner">Owner.</param>
+        /// <returns></returns>
+        public static int UnLock(Uri path, string locktoken, string owner)
+        {
+            CleanLocks(path);
+            if (string.IsNullOrEmpty(locktoken))
+            {
+                WebDavServer.Log.Debug("Unlock failed, No Token!.");
+                return (int)HttpStatusCode.BadRequest;
+            }
+
+            lock (ObjectLocks)
+            {
+                if (!ObjectLocks.ContainsKey(path))
+                {
+                    WebDavServer.Log.Debug("Unlock failed, Lock does not exist!.");
+                    return (int)HttpStatusCode.Conflict;
+                }
+
+                WebDaveStoreItemLockInstance ilock = ObjectLocks[path].FirstOrDefault(d => d.Token == locktoken && d.Owner == owner);
+                if (ilock == null)
+                    return (int)HttpStatusCode.Conflict;
+                //Remove the lock
+                ObjectLocks[path].Remove(ilock);
+
+                //if there are no locks left of the uri then remove it from ObjectLocks.
+                if (ObjectLocks[path].Count == 0)
+                    ObjectLocks.Remove(path);
+
+                WebDavServer.Log.Debug("Unlock successful.");
+                return (int)HttpStatusCode.NoContent;
+            }
+        }
+
+        /// <summary>
+        /// Returns all the locks on the path
+        /// </summary>
+        /// <param name="path">URI to resource</param>
+        /// <returns></returns>
+        public static List<WebDaveStoreItemLockInstance> GetLocks(Uri path)
+        {
+            return ObjectLocks.ContainsKey(path) ? ObjectLocks[path].ToList() : new List<WebDaveStoreItemLockInstance>();
+        }
+    }
+}

--- a/Stores/Locks/WebDaveStoreItemLockInstance.cs
+++ b/Stores/Locks/WebDaveStoreItemLockInstance.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace WebDAVSharp.Server.Stores.Locks
+{
+    /// <summary>
+    /// Used to store locks on objects
+    /// </summary>
+    public class WebDaveStoreItemLockInstance
+    {
+        /// <summary>
+        /// The Path locked
+        /// </summary>
+        public Uri Path
+        {
+            get;
+            private set;
+        }
+
+
+        /// <summary>
+        /// Lock Scope
+        /// </summary>
+        public WebDavLockScope LockScope
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Lock Type
+        /// </summary>
+        public WebDavLockType LockType
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Owner
+        /// </summary>
+        public string Owner
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Requested Timeout
+        /// </summary>
+        public string RequestedTimeout
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Token Issued
+        /// </summary>
+        public string Token
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Request Document
+        /// </summary>
+        public XmlDocument RequestDocument
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// If null, it's an infinite checkout.
+        /// </summary>
+        public DateTime? ExpirationDate
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public int Depth
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="path"></param>
+        /// <param name="lockscope"></param>
+        /// <param name="locktype"></param>
+        /// <param name="owner"></param>
+        /// <param name="requestedlocktimeout"></param>
+        /// <param name="token"></param>
+        /// <param name="requestdocument"></param>
+        /// <param name="depth"></param>
+        public WebDaveStoreItemLockInstance(Uri path, WebDavLockScope lockscope, WebDavLockType locktype, string owner, ref string requestedlocktimeout, ref string token, XmlDocument requestdocument, int depth)
+        {
+            Path = path;
+            LockScope = lockscope;
+            LockType = locktype;
+            Owner = owner;
+            Token = token;
+            RequestDocument = requestdocument;
+            Token = token = "urn:uuid:" + Guid.NewGuid();
+            Depth = depth;
+            RefreshLock(ref requestedlocktimeout);
+        }
+
+        /// <summary>
+        /// Refreshes a lock
+        /// </summary>
+        /// <param name="requestedlocktimeout"></param>
+        public void RefreshLock(ref string requestedlocktimeout)
+        {
+            if (requestedlocktimeout.Contains("Infinite") && WebDavStoreItemLock.AllowInfiniteCheckouts)
+            {
+                requestedlocktimeout = "Infinite";
+                ExpirationDate = null;
+                return;
+            }
+            string seconds = requestedlocktimeout.Substring(requestedlocktimeout.IndexOf("Second-", System.StringComparison.Ordinal) + 7);
+            long lseconds;
+            if (long.TryParse(seconds, out lseconds))
+            {
+                if (lseconds > WebDavStoreItemLock.MaxCheckOutSeconds)
+                    lseconds = WebDavStoreItemLock.MaxCheckOutSeconds;
+                RequestedTimeout = requestedlocktimeout = "Second-" + lseconds;
+
+                //Due to latency, if the seconds granted is less than max seconds - 60 then we give them a 1 minute buffer.
+                ExpirationDate = DateTime.Now.AddSeconds(lseconds < long.MaxValue - 60 ? lseconds + 60 : lseconds);
+            }
+            else
+            {
+                RequestedTimeout = requestedlocktimeout = "Second-" + WebDavStoreItemLock.MaxCheckOutSeconds;
+                ExpirationDate = DateTime.Now.AddSeconds(WebDavStoreItemLock.MaxCheckOutSeconds);
+            }
+        }
+
+    }
+}

--- a/WebDAVDisposableBase.cs
+++ b/WebDAVDisposableBase.cs
@@ -7,8 +7,13 @@ namespace WebDAVSharp.Server
     /// </summary>
     public abstract class WebDavDisposableBase : IDisposable
     {
+        #region Properties
+
         private bool _isDisposed;
 
+        #endregion
+
+        #region Functions
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
@@ -32,10 +37,16 @@ namespace WebDAVSharp.Server
                 throw new ObjectDisposedException(GetType().FullName);
         }
 
+        #endregion
+
+        #region Abstract Functions
+
         /// <summary>
         /// Releases unmanaged and - optionally - managed resources
         /// </summary>
         /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
         protected abstract void Dispose(bool disposing);
+
+        #endregion
     }
 }

--- a/WebDAVExtensions.cs
+++ b/WebDAVExtensions.cs
@@ -47,13 +47,13 @@ namespace WebDAVSharp.Server
         /// <param name="statusCode">The HTTP status code for the response.</param>
         /// <exception cref="System.ArgumentNullException">context</exception>
         /// <exception cref="ArgumentNullException"><paramref name="context" /> is <c>null</c>.</exception>
-        public static void SendSimpleResponse(this IHttpListenerContext context, HttpStatusCode statusCode = HttpStatusCode.OK)
+        public static void SendSimpleResponse(this IHttpListenerContext context, int statusCode = (int)HttpStatusCode.OK)
         {
             if (context == null)
                 throw new ArgumentNullException("context");
 
-            context.Response.StatusCode = (int)statusCode;
-            context.Response.StatusDescription = HttpWorkerRequest.GetStatusDescription((int)statusCode);
+            context.Response.StatusCode = statusCode;
+            context.Response.StatusDescription = HttpWorkerRequest.GetStatusDescription(statusCode);
             context.Response.Close();
         }
 
@@ -71,12 +71,14 @@ namespace WebDAVSharp.Server
         /// <exception cref="WebDavInternalServerException"><paramref name="uri" /> specifies a <see cref="Uri" /> that is not known to the <paramref name="server" />.</exception>
         public static Uri GetPrefixUri(this Uri uri, WebDavServer server)
         {
-            string url = uri.ToString();
-            foreach (
-                string prefix in
-                    server.Listener.Prefixes.Where(
-                        prefix => url.StartsWith(uri.ToString(), StringComparison.OrdinalIgnoreCase)))
-                return new Uri(prefix);
+
+                string url = uri.ToString();
+                foreach (
+                    string prefix in
+                        server.Listener.Prefixes.Where(
+                            prefix => url.StartsWith(uri.ToString(), StringComparison.OrdinalIgnoreCase)))
+                    return new Uri(prefix);
+           
             throw new WebDavInternalServerException("Unable to find correct server root");
         }
 

--- a/WebDAVProperty.cs
+++ b/WebDAVProperty.cs
@@ -7,6 +7,9 @@ namespace WebDAVSharp.Server
     /// </summary>
     internal class WebDavProperty
     {
+
+        #region Variables
+
         /// <summary>
         /// This class implements the core WebDAV server.
         /// </summary>
@@ -21,6 +24,10 @@ namespace WebDAVSharp.Server
         /// This class implements the core WebDAV server.
         /// </summary>
         public string Value;
+
+        #endregion
+
+        #region Constructor
 
         /// <summary>
         /// Standard constructor
@@ -67,6 +74,10 @@ namespace WebDAVSharp.Server
             Value = value;
             Namespace = ns;
         }
+
+        #endregion
+
+        #region Functions
 
         /// <summary>
         /// This class implements the core WebDAV server.
@@ -146,5 +157,8 @@ namespace WebDAVSharp.Server
             return element;
             // else, return XmlElement without namespace
         }
+
+        #endregion
+
     }
 }

--- a/WebDAVProperty.cs
+++ b/WebDAVProperty.cs
@@ -158,6 +158,27 @@ namespace WebDAVSharp.Server
             // else, return XmlElement without namespace
         }
 
+        /// <summary>
+        /// reates an XmlElement from the current WebDAVProperty
+        /// </summary>
+        /// <param name="doc">The XmlDocument where a XmlElement is needed</param>
+        /// <returns>
+        /// The XmlElement of the current WebDAVProperty object
+        /// </returns>
+        public XmlElement XmlToXmlElement(XmlDocument doc)
+        {
+            // if the DocumentElement is not null, return the XmlElement with namespace
+            if (doc.DocumentElement == null)
+                return doc.CreateElement(Name);
+            // Get the prefix of the namespace
+            string prefix = doc.DocumentElement.GetPrefixOfNamespace(Namespace);
+
+            // Create the element
+            XmlElement element = doc.CreateElement(prefix, Name, Namespace);
+            element.InnerXml = Value;
+            return element;
+            // else, return XmlElement without namespace
+        }
         #endregion
 
     }

--- a/WebDAVServer.cs
+++ b/WebDAVServer.cs
@@ -12,6 +12,7 @@ using WebDAVSharp.Server.Adapters.AuthenticationTypes;
 using WebDAVSharp.Server.Exceptions;
 using WebDAVSharp.Server.MethodHandlers;
 using WebDAVSharp.Server.Stores;
+using WebDAVSharp.Server.Stores.Locks;
 
 namespace WebDAVSharp.Server
 {
@@ -40,6 +41,35 @@ namespace WebDAVSharp.Server
 
         #region Properties
 
+        /// <summary>
+        /// Allow users to have Indefinite Locks
+        /// </summary>
+        public bool AllowInfiniteCheckouts
+        {
+            get
+            {
+                return WebDavStoreItemLock.AllowInfiniteCheckouts;
+            }
+            set
+            {
+                WebDavStoreItemLock.AllowInfiniteCheckouts = value;
+            }
+        }
+
+        /// <summary>
+        /// The maximum number of seconds a person can check an item out for.
+        /// </summary>
+        public long MaxCheckOutSeconds
+        {
+            get
+            {
+                return WebDavStoreItemLock.MaxCheckOutSeconds;
+            }
+            set
+            {
+                WebDavStoreItemLock.MaxCheckOutSeconds = value;
+            }
+        }
         internal static ILog Log
         {
             get
@@ -78,6 +108,7 @@ namespace WebDAVSharp.Server
                 return _listener;
             }
         }
+
         #endregion
 
         #region Constructor

--- a/WebDAVServer.cs
+++ b/WebDAVServer.cs
@@ -18,20 +18,66 @@ namespace WebDAVSharp.Server
     /// </summary>
     public class WebDavServer : WebDavDisposableBase
     {
-        /// <summary>
-        /// The HTTP user
-        /// </summary>
-        public const string HttpUser = "HTTP.User";
 
+        #region Variables
+
+        internal const string HttpUser = "HTTP.User";
         private readonly IHttpListener _listener;
         private readonly bool _ownsListener;
         private readonly IWebDavStore _store;
         private readonly Dictionary<string, IWebDavMethodHandler> _methodHandlers;
-        private readonly ILog _log;
+        internal readonly static ILog _log = LogManager.GetCurrentClassLogger();
         private readonly object _threadLock = new object();
 
         private ManualResetEvent _stopEvent;
         private Thread _thread;
+
+        #endregion
+
+        #region Properties
+
+        internal static ILog Log
+        {
+            get
+            {
+                return _log;
+            }
+        }
+
+        /// <summary>
+        /// Gets the 
+        /// <see cref="IHttpListener" /> that this 
+        /// <see cref="WebDavServer" /> uses for
+        /// the web server portion.
+        /// </summary>
+        /// <value>
+        /// The listener.
+        /// </value>
+        internal IHttpListener Listener
+        {
+            get
+            {
+                return _listener;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IWebDavStore" /> this <see cref="WebDavServer" /> is hosting.
+        /// </summary>
+        /// <value>
+        /// The store.
+        /// </value>
+        public IWebDavStore Store
+        {
+            get
+            {
+                return _store;
+            }
+        }
+
+        #endregion
+
+        #region Constructor
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WebDavServer" /> class.
@@ -87,39 +133,11 @@ namespace WebDAVSharp.Server
                     methodHandler
                 };
             _methodHandlers = handlersWithNames.ToDictionary(v => v.name, v => v.methodHandler);
-            _log = LogManager.GetCurrentClassLogger();
-            }
-
-        /// <summary>
-        /// Gets the 
-        /// <see cref="IHttpListener" /> that this 
-        /// <see cref="WebDavServer" /> uses for
-        /// the web server portion.
-        /// </summary>
-        /// <value>
-        /// The listener.
-        /// </value>
-        internal IHttpListener Listener
-        {
-            get
-            {
-                return _listener;
-            }
         }
 
-        /// <summary>
-        /// Gets the <see cref="IWebDavStore" /> this <see cref="WebDavServer" /> is hosting.
-        /// </summary>
-        /// <value>
-        /// The store.
-        /// </value>
-        public IWebDavStore Store
-        {
-            get
-            {
-                return _store;
-            }
-        }
+        #endregion
+
+        #region Functions
 
         /// <summary>
         /// Releases unmanaged and - optionally - managed resources
@@ -145,17 +163,17 @@ namespace WebDAVSharp.Server
         /// <exception cref="System.InvalidOperationException">This WebDAVServer instance is already running, call to Start is invalid at this point</exception>
         /// <exception cref="ObjectDisposedException">This <see cref="WebDavServer" /> instance has been disposed of.</exception>
         /// <exception cref="InvalidOperationException">The server is already running.</exception>
-        public void Start(String Url)
-            {
-            Listener.Prefixes.Add(Url);
+        public void Start(String url)
+        {
+            Listener.Prefixes.Add(url);
             EnsureNotDisposed();
             lock (_threadLock)
-                {
+            {
                 if (_thread != null)
-                    {
+                {
                     throw new InvalidOperationException(
                         "This WebDAVServer instance is already running, call to Start is invalid at this point");
-                    }
+                }
 
                 _stopEvent = new ManualResetEvent(false);
 
@@ -182,10 +200,10 @@ namespace WebDAVSharp.Server
             lock (_threadLock)
             {
                 if (_thread == null)
-                    {
+                {
                     throw new InvalidOperationException(
                         "This WebDAVServer instance is not running, call to Stop is invalid at this point");
-                    }
+                }
 
                 _stopEvent.Set();
                 _thread.Join();
@@ -307,5 +325,7 @@ namespace WebDAVSharp.Server
                 _log.Info(context.Response.StatusCode + " " + context.Response.StatusDescription + ": " + context.Request.HttpMethod + " " + context.Request.RemoteEndPoint + ": " + context.Request.Url);
             }
         }
+
+        #endregion
     }
 }

--- a/WebDAVSharp.Server.csproj
+++ b/WebDAVSharp.Server.csproj
@@ -74,6 +74,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Adapters\AuthenticationTypes\HttpListenerAnyonymousAdapter.cs" />
+    <Compile Include="Adapters\AuthenticationTypes\HttpListenerBasicAdapter.cs" />
     <Compile Include="Adapters\HttpListenerContextAdapter.cs" />
     <Compile Include="Adapters\HttpListenerRequestAdapter.cs" />
     <Compile Include="Adapters\HttpListenerResponseAdapter.cs" />
@@ -105,6 +107,10 @@
     <Compile Include="MethodHandlers\WebDavProppatchMethodHandler.cs" />
     <Compile Include="MethodHandlers\WebDavPutMethodHandler.cs" />
     <Compile Include="MethodHandlers\WebDavUnlockMethodHandler.cs" />
+    <Compile Include="Stores\Locks\WebDavLockScope.cs" />
+    <Compile Include="Stores\Locks\WebDavLockType.cs" />
+    <Compile Include="Stores\Locks\WebDaveStoreItemLockInstance.cs" />
+    <Compile Include="Stores\Locks\WebDavStoreItemLock.cs" />
     <Compile Include="Utilities\Md5Util.cs" />
     <Compile Include="Stores\BaseClasses\WebDavStoreDocumentBase.cs" />
     <Compile Include="Stores\BaseClasses\WebDavStoreBase.cs" />
@@ -122,11 +128,12 @@
     <Compile Include="Stores\IWebDavStoreDocument.cs" />
     <Compile Include="Stores\IWebDavStoreItem.cs" />
     <Compile Include="Utilities\WebDavStatusCode.cs" />
+    <Compile Include="WebDavAuthType.cs" />
     <Compile Include="WebDavDisposableBase.cs" />
     <Compile Include="WebDavExtensions.cs" />
     <Compile Include="WebDavProperty.cs" />
     <Compile Include="WebDavServer.cs" />
-    <Compile Include="Adapters\HttpListenerAdapter.cs" />
+    <Compile Include="Adapters\AuthenticationTypes\HttpListenerNegotiateAdapter.cs" />
     <Compile Include="MethodHandlers\WebDavMethodHandlers.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/WebDavAuthType.cs
+++ b/WebDavAuthType.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WebDAVSharp.Server
+{
+
+    /// <summary>
+    /// HTTP Authorization Types
+    /// </summary>
+    public enum AuthType
+    {
+        /// <summary>
+        /// Clear Text
+        /// </summary>
+        Basic,
+        /// <summary>
+        /// Negotiate
+        /// </summary>
+        Negotiate,
+        /// <summary>
+        /// Anonymous
+        /// </summary>
+        Anonymous
+    }
+}


### PR DESCRIPTION
Added support for Locks according to http://www.webdav.org/specs/rfc4918.html
-Only thing I didn't implement was infinite Depth Locks, so you can only lock one file at a time versus locking a folder and everything below it.
-Added support for Lock Scope of Exclusive and Shared
-Added support for Lock Type of write
-Added to PropFind method handler (lockdiscovery, supportedlock)

Also added support for other Authentication modes, Basic, Anonymous and Negotiate
-Refactored the WebDevServer Constructor, added a new constructor where you can specify the type of Authentication mode you want to use.
-Moved the HttpListnerAdapters down into a folder called AuthenticationTypes (Since we now have 3)

